### PR TITLE
Allow for django to cache model content type after first call

### DIFF
--- a/src/rest_framework_guardian/filters.py
+++ b/src/rest_framework_guardian/filters.py
@@ -8,7 +8,7 @@ class ObjectPermissionsFilter(BaseFilterBackend):
     A filter backend that limits results to those where the requesting user
     has read object level permissions.
     """
-    perm_format = '%(app_label)s.view_%(model_name)s'
+    perm_format = 'view_%(model_name)s'
     shortcut_kwargs = {
         'accept_global_perms': False,
     }
@@ -21,7 +21,6 @@ class ObjectPermissionsFilter(BaseFilterBackend):
 
         user = request.user
         permission = self.perm_format % {
-            'app_label': queryset.model._meta.app_label,
             'model_name': queryset.model._meta.model_name,
         }
 


### PR DESCRIPTION
Related to: https://github.com/rpkilby/django-rest-framework-guardian/issues/14

As seen in the first capture, 5 db calls are issued with current `get_objects_for_user`
![guardian_1](https://user-images.githubusercontent.com/1755599/85932093-63571000-b886-11ea-9828-1b1d4b96957c.PNG)

In this next capture, 4 db calls are issued with new call to `get_objects_for_user`
![guardian_2](https://user-images.githubusercontent.com/1755599/85932098-66ea9700-b886-11ea-9b45-db6a4e0e5afe.PNG)
