### PR TITLE
Support Django 4.0 and 3.2 and drop previous Django versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,20 @@ jobs:
     docker:
       - image: circleci/python:3.7
 
+  test-py310:
+    <<: *test-steps
+    docker:
+      - image: circleci/python:3.10
+    environment:
+      TOXENV: py310
+
+  test-py39:
+    <<: *test-steps
+    docker:
+      - image: circleci/python:3.9
+    environment:
+      TOXENV: py39
+
   test-py38:
     <<: *test-steps
     docker:
@@ -81,6 +95,14 @@ workflows:
     jobs:
       - lint
       - dist:
+          requires:
+            - lint
+
+      - test-py310:
+          requires:
+            - lint
+
+      - test-py39:
           requires:
             - lint
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - *install
       - run: tox -e isort,lint,readme
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
 
   dist:
     steps:
@@ -44,7 +44,7 @@ jobs:
           tox -e dist --installpkg ./dist/djangorestframework_guardian-*.whl
           tox -e dist
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
 
   test-py310:
     <<: *test-steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,13 +81,6 @@ jobs:
     environment:
       TOXENV: py36
 
-  test-py35:
-    <<: *test-steps
-    docker:
-      - image: circleci/python:3.5
-    environment:
-      TOXENV: py35
-
 
 workflows:
   version: 2
@@ -115,10 +108,6 @@ workflows:
             - lint
 
       - test-py36:
-          requires:
-            - lint
-
-      - test-py35:
           requires:
             - lint
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,10 @@ workflows:
           requires:
             - lint
 
+      - test-py38:
+          requires:
+            - lint
+
       - test-py37:
           requires:
             - lint

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,9 +44,8 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 2.2
-    Framework :: Django :: 3.0
-    Framework :: Django :: 3.1
+    Framework :: Django :: 3.2
+    Framework :: Django :: 4.0
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,8 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Internet :: WWW/HTTP
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,9 +44,9 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 2.1
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
+    Framework :: Django :: 3.1
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class BasicModel(models.Model):

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ setenv =
     PYTHONDONTWRITEBYTECODE = 1
 deps =
     coverage
-    django21: Django~=2.1
     django22: Django~=2.2
     django30: Django~=3.0
     django31: Django~=3.1

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     isort
 
 [testenv:lint]
-commands = flake8 src tests {posargs}
+commands = flake8 --ignore=B023 src tests {posargs}
 deps =
     flake8
     flake8-bugbear

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        {py35,py36,py37,py38}-django22,
-       {py36,py37,py38}-django{30,31},
+       {py36,py37,py38,py39,py310}-django{30,31,32},
        dist,isort,lint,readme
 
 [testenv]
@@ -15,6 +15,7 @@ deps =
     django22: Django~=2.2
     django30: Django~=3.0
     django31: Django~=3.1
+    django32: Django~=3.2
 
 [testenv:dist]
 commands = python manage.py test {posargs: --no-input -v 2}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-       {py35,py36,py37,py38}-django22,
-       {py36,py37,py38,py39,py310}-django{30,31,32},
+       {py36,py37,py38,py39,py310}-django32,
+       {py38,py39,py310}-django40,
        dist,isort,lint,readme
 
 [testenv]
@@ -12,10 +12,8 @@ setenv =
     PYTHONDONTWRITEBYTECODE = 1
 deps =
     coverage
-    django22: Django~=2.2
-    django30: Django~=3.0
-    django31: Django~=3.1
     django32: Django~=3.2
+    django40: Django~=4.0
 
 [testenv:dist]
 commands = python manage.py test {posargs: --no-input -v 2}

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
-       {py35,py36,py37}-django21,
        {py35,py36,py37,py38}-django22,
-       {py36,py37,py38}-django30,
+       {py36,py37,py38}-django{30,31},
        dist,isort,lint,readme
 
 [testenv]
@@ -16,6 +15,7 @@ deps =
     django21: Django~=2.1
     django22: Django~=2.2
     django30: Django~=3.0
+    django31: Django~=3.1
 
 [testenv:dist]
 commands = python manage.py test {posargs: --no-input -v 2}


### PR DESCRIPTION
This pull request uses #17 as a base (thanks @johnthagen) but also includes Django 4 support. It also removes support for Django 3.0 and 3.1 as they are EOL. The lint error B023 is ignored since it was causing issues with circleci through the TestSerializer class declared in a loop.